### PR TITLE
Update OpenVPN link to point to GitHub repository

### DIFF
--- a/Links/OPENVPN26
+++ b/Links/OPENVPN26
@@ -1,1 +1,1 @@
-https://community.openvpn.net/openvpn/wiki/ChangesInOpenvpn26#Changesin%s
+https://github.com/OpenVPN/openvpn/blob/v%s/Changes.rst


### PR DESCRIPTION
Old link doesn't have releases past 2.6.14.