### PR TITLE
Update LIBXML link to use version placeholder

### DIFF
--- a/Links/LIBXML
+++ b/Links/LIBXML
@@ -1,1 +1,1 @@
-https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS
+https://gitlab.gnome.org/GNOME/libxml2/-/blob/v%s/NEWS


### PR DESCRIPTION
Release notes aren't being updated on the old link, this should resolve this.